### PR TITLE
UI clarity: simplify action logging language

### DIFF
--- a/frontend/src/components/CheckinForm.tsx
+++ b/frontend/src/components/CheckinForm.tsx
@@ -20,7 +20,7 @@ export const CheckinForm = ({
       <form onSubmit={onSubmit} className="form">
         <div className="checkin-fields">
           <label htmlFor="checkin-title" className="checkin-label">
-            What small step will keep this alive?
+            Log small action you just completed:
           </label>
 
           <input
@@ -28,7 +28,7 @@ export const CheckinForm = ({
             className="checkin-title-input"
             id="checkin-title"
             value={checkinTitle}
-            placeholder="Step title"
+            placeholder="What action did you take?"
             required
             onChange={(e) => onCheckinTitleChange(e.target.value)}
           />
@@ -44,7 +44,7 @@ export const CheckinForm = ({
           />
         </div>
 
-        <button data-testid="save-checkin-button">Save and continue</button>
+        <button data-testid="save-checkin-button">Save</button>
       </form>
     </div>
   );

--- a/frontend/src/components/CheckinsHistory.tsx
+++ b/frontend/src/components/CheckinsHistory.tsx
@@ -58,7 +58,7 @@ type CheckinsHistoryProps = {
 export const CheckinsHistory = ({ checkins }: CheckinsHistoryProps) => {
   return (
     <div className="checkins-history" data-testid="checkins-history">
-      <p className="checkins-label">Recent steps:</p>
+      <p className="checkins-label">Activity log:</p>
 
       {checkins.length === 0 ? (
         <p className="empty-state">No steps yet. Start by adding one.</p>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -169,7 +169,7 @@ export const HomePage = () => {
   const selectedThreadCheckins = checkinsHistory
     .filter((checkin) => checkin.threadId === selectedThreadId)
     .sort((a, b) => b.createdAt - a.createdAt) // newest first;
-    .slice(0, 3) // show only last 3;
+    .slice(0, 6) // show only last 6;
     .reverse();
 
   const checkinsCountForSelectedThread = selectedThreadId


### PR DESCRIPTION
## What this PR delivers

Small UI copy improvements based on user testing feedback.

Changes include:
- Rename **Recent steps → Activity log**
- Rename **Save and continue → Save**
- Update input label **Step title → What action did you take?**
- Add helper text: *"Log the small action you just completed"*
- Show more history (last 6 steps)

## Why it matters

User testing revealed confusion around:
- whether steps represent **planned tasks** or **completed actions**
- what **"Save and continue"** actually does
- how the step list should be interpreted

These copy changes clarify that GoBack is primarily a **log of completed actions**, helping users return to their projects and see where they left off.

## Result

Clearer mental model for users:

past actions → activity log  
present action → log what you just did

This aligns the interface with GoBack's core idea:
**Return → Remember → Continue.**