### PR TITLE
docs: add product decisions for guest and auth data flow

### DIFF
--- a/frontend/docs/product-decisions.md
+++ b/frontend/docs/product-decisions.md
@@ -1,0 +1,14 @@
+# Product decisions
+
+## Guest vs authenticated data flow
+
+Guests use localStorage.
+
+Authenticated users use Supabase.
+
+Guest data syncs once on first login.
+
+Sync flag:
+goback_synced_user_id
+
+Repeated automatic sync is out of scope.


### PR DESCRIPTION
### What this PR delivers
- adds frontend/docs/product-decisions.md
- documents the current decision for guest vs authenticated data flow

### Why it matters
- keeps an important product/data decision outside issue comments
- gives future implementation work a clear reference point
- prevents rethinking sync behavior while building Supabase integration