### PR TITLE
Supabase: authenticated thread persistence and guest sync groundwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /backend/node_modules
 /frontend/node_modules
 .env
+.env.local
 
 # macOS files
 .DS_Store

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 test-results/
 playwright-report/
+
+.env
+.env.local

--- a/frontend/lib/createThreadForUser.ts
+++ b/frontend/lib/createThreadForUser.ts
@@ -1,0 +1,19 @@
+import { supabase } from './supabaseClient';
+
+export async function createThreadForUser(userId: string, name: string) {
+  const { data, error } = await supabase
+    .from('threads')
+    .insert([
+      {
+        user_id: userId,
+        name,
+        is_archived: false,
+      },
+    ])
+    .select()
+    .single();
+
+  if (error) throw error;
+
+  return data;
+}

--- a/frontend/lib/getCheckinsForUser.ts
+++ b/frontend/lib/getCheckinsForUser.ts
@@ -1,0 +1,13 @@
+import { supabase } from './supabaseClient';
+
+export async function getCheckinsForUser(userId: string) {
+  const { data, error } = await supabase
+    .from('checkins')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+
+  return data;
+}

--- a/frontend/lib/getThreadsForUser.ts
+++ b/frontend/lib/getThreadsForUser.ts
@@ -1,0 +1,16 @@
+import { supabase } from '../lib/supabaseClient';
+
+export async function getThreadsForUser(userId: string) {
+  const { data, error } = await supabase
+    .from('threads')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('is_archived', false)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}

--- a/frontend/lib/importGuestCheckinsForUser.ts
+++ b/frontend/lib/importGuestCheckinsForUser.ts
@@ -1,0 +1,26 @@
+import { supabase } from './supabaseClient';
+import type { Checkin } from '../src/types/types';
+
+export async function importGuestCheckinsForUser(
+  userId: string,
+  checkins: Checkin[],
+  threadIdMap: Record<string, string>,
+) {
+  const rows = checkins
+    .filter((checkin) => threadIdMap[checkin.threadId])
+    .map((checkin) => ({
+      user_id: userId,
+      thread_id: threadIdMap[checkin.threadId],
+      text: checkin.text,
+      note: checkin.note ?? null,
+      created_at: new Date(checkin.createdAt).toISOString(),
+    }));
+
+  if (rows.length === 0) return;
+
+  const { error } = await supabase.from('checkins').insert(rows);
+
+  if (error) {
+    throw error;
+  }
+}

--- a/frontend/lib/importGuestThreadsForUser.ts
+++ b/frontend/lib/importGuestThreadsForUser.ts
@@ -1,0 +1,31 @@
+import { supabase } from './supabaseClient';
+import type { Thread } from '../src/types/types';
+
+type ThreadIdMap = Record<string, string>;
+
+export async function importGuestThreadsForUser(
+  userId: string,
+  guestThreads: Thread[],
+) {
+  const threadIdMap: ThreadIdMap = {};
+
+  for (const guestThread of guestThreads) {
+    const { data, error } = await supabase
+      .from('threads')
+      .insert([
+        {
+          user_id: userId,
+          name: guestThread.name,
+          is_archived: guestThread.isArchived ?? false,
+        },
+      ])
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    threadIdMap[guestThread.id] = data.id;
+  }
+
+  return threadIdMap;
+}

--- a/frontend/lib/shouldSyncGuestData.ts
+++ b/frontend/lib/shouldSyncGuestData.ts
@@ -1,0 +1,29 @@
+function safeCount(value: string | null) {
+  if (!value) return 0;
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function shouldSyncGuestData(
+  userId: string,
+  threadsStorageKey: string,
+  checkinsStorageKey: string,
+  syncedUserKey: string,
+) {
+  const syncedUserId = localStorage.getItem(syncedUserKey);
+
+  const hasGuestThreads =
+    safeCount(localStorage.getItem(threadsStorageKey)) > 0;
+  const hasGuestCheckins =
+    safeCount(localStorage.getItem(checkinsStorageKey)) > 0;
+
+  const hasGuestData = hasGuestThreads || hasGuestCheckins;
+  const alreadySyncedForThisUser = syncedUserId === userId;
+
+  return hasGuestData && !alreadySyncedForThisUser;
+}

--- a/frontend/lib/supabaseClient.ts
+++ b/frontend/lib/supabaseClient.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+if (
+  !import.meta.env.VITE_SUPABASE_URL ||
+  !import.meta.env.VITE_SUPABASE_ANON_KEY
+) {
+  throw new Error('Missing Supabase env variables');
+}
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+);
+
+console.log('Supabase client ready');

--- a/frontend/lib/supabaseClient.ts
+++ b/frontend/lib/supabaseClient.ts
@@ -11,5 +11,3 @@ export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL,
   import.meta.env.VITE_SUPABASE_ANON_KEY,
 );
-
-console.log('Supabase client ready');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@picocss/pico": "^2.1.1",
+        "@supabase/supabase-js": "^2.98.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.11.0"
@@ -1349,6 +1350,86 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.98.0",
+        "@supabase/functions-js": "2.98.0",
+        "@supabase/postgrest-js": "2.98.0",
+        "@supabase/realtime-js": "2.98.0",
+        "@supabase/storage-js": "2.98.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1412,11 +1493,16 @@
       "version": "24.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.2.tgz",
       "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
@@ -1436,6 +1522,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2419,6 +2514,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3094,6 +3198,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3149,7 +3259,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3292,6 +3401,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@picocss/pico": "^2.1.1",
+    "@supabase/supabase-js": "^2.98.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.11.0"

--- a/frontend/src/components/AuthButton.tsx
+++ b/frontend/src/components/AuthButton.tsx
@@ -1,36 +1,9 @@
-import { useEffect, useState } from 'react';
-import type { User } from '@supabase/supabase-js';
-import { supabase } from '../../lib/supabaseClient';
 import { LoginButton } from './LoginButton';
 import { LogoutButton } from './LogoutButton';
+import { useAuthUser } from '../hooks/useAuthUser';
 
 export const AuthButton = () => {
-  const [user, setUser] = useState<User | null>(null);
-  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
-
-  useEffect(() => {
-    const getUser = async () => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      setUser(user);
-      setIsCheckingAuth(false);
-    };
-
-    getUser();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
-      setIsCheckingAuth(false);
-    });
-
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, []);
+  const { user, isCheckingAuth } = useAuthUser();
 
   if (isCheckingAuth) {
     return <p>Checking auth...</p>;

--- a/frontend/src/components/AuthButton.tsx
+++ b/frontend/src/components/AuthButton.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabaseClient';
+import { LoginButton } from './LoginButton';
+import { LogoutButton } from './LogoutButton';
+
+export const AuthButton = () => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const getUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      setUser(user);
+      setIsCheckingAuth(false);
+    };
+
+    getUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+      setIsCheckingAuth(false);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  if (isCheckingAuth) {
+    return <p>Checking auth...</p>;
+  }
+
+  return user ? <LogoutButton /> : <LoginButton />;
+};

--- a/frontend/src/components/GoBackCard.tsx
+++ b/frontend/src/components/GoBackCard.tsx
@@ -6,6 +6,7 @@ import { CheckinsHistory } from './CheckinsHistory';
 
 interface GoBackCardProps {
   selectedThread: Thread | null;
+  isLoadingSelection?: boolean;
 
   checkinTitle: string;
   checkinNote: string;
@@ -31,6 +32,7 @@ interface GoBackCardProps {
 
 export const GoBackCard = ({
   selectedThread,
+  isLoadingSelection = false,
   checkinTitle,
   onCheckinTitleChange,
   checkinNote,
@@ -52,7 +54,9 @@ export const GoBackCard = ({
 }: GoBackCardProps) => {
   return (
     <div className="card" data-testid="go-back-card">
-      {selectedThread ? (
+      {isLoadingSelection ? (
+        <p>Loading activity...</p>
+      ) : selectedThread ? (
         <>
           <SelectedThreadHeader
             selectedThread={selectedThread}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -60,6 +60,7 @@ export const Header = ({ heroDismissed = false, onShowIntro }: HeaderProps) => {
           </button>
         )}
       </nav>
+
       <AuthButton />
     </header>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import '../styles/components/header.css';
 import { useState } from 'react';
+import { AuthButton } from './AuthButton';
 
 type HeaderProps = {
   heroDismissed?: boolean;
@@ -59,6 +60,7 @@ export const Header = ({ heroDismissed = false, onShowIntro }: HeaderProps) => {
           </button>
         )}
       </nav>
+      <AuthButton />
     </header>
   );
 };

--- a/frontend/src/components/LoginButton.tsx
+++ b/frontend/src/components/LoginButton.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+
+export const LoginButton = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleGoogleLogin = async () => {
+    try {
+      setIsLoading(true);
+
+      await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          queryParams: {
+            prompt: 'select_account',
+          },
+        },
+      });
+    } catch (error) {
+      console.error('Google login failed', error);
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleGoogleLogin} disabled={isLoading}>
+      {isLoading ? 'Redirecting...' : 'Continue with Google'}
+    </button>
+  );
+};

--- a/frontend/src/components/LoginButton.tsx
+++ b/frontend/src/components/LoginButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { supabase } from '../../lib/supabaseClient';
+import '../styles/components/auth-button.css';
 
 export const LoginButton = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -23,7 +24,12 @@ export const LoginButton = () => {
   };
 
   return (
-    <button type="button" onClick={handleGoogleLogin} disabled={isLoading}>
+    <button
+      className="auth-button"
+      type="button"
+      onClick={handleGoogleLogin}
+      disabled={isLoading}
+    >
       {isLoading ? 'Redirecting...' : 'Continue with Google'}
     </button>
   );

--- a/frontend/src/components/LogoutButton.tsx
+++ b/frontend/src/components/LogoutButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { supabase } from '../../lib/supabaseClient';
+import '../styles/components/auth-button.css';
 
 export const LogoutButton = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -15,7 +16,12 @@ export const LogoutButton = () => {
   };
 
   return (
-    <button type="button" onClick={handleLogout} disabled={isLoading}>
+    <button
+      className="auth-button"
+      type="button"
+      onClick={handleLogout}
+      disabled={isLoading}
+    >
       {isLoading ? 'Signing out...' : 'Logout'}
     </button>
   );

--- a/frontend/src/components/LogoutButton.tsx
+++ b/frontend/src/components/LogoutButton.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+
+export const LogoutButton = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogout = async () => {
+    try {
+      setIsLoading(true);
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Logout failed', error);
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleLogout} disabled={isLoading}>
+      {isLoading ? 'Signing out...' : 'Logout'}
+    </button>
+  );
+};

--- a/frontend/src/hooks/useAuthUser.ts
+++ b/frontend/src/hooks/useAuthUser.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '../../lib/supabaseClient';
+
+export function useAuthUser() {
+  const [user, setUser] = useState<User | null>(null);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const getUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      setUser(user);
+      setIsCheckingAuth(false);
+    };
+
+    getUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+      setIsCheckingAuth(false);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return { user, isCheckingAuth };
+}

--- a/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
+++ b/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
@@ -102,7 +102,12 @@ export function useAuthWorkspaceBootstrap({
               threadIdMap,
             );
 
+            // clear guest local data after successful first sync
             localStorage.setItem(syncedUserKey, user.id);
+            localStorage.removeItem(threadsStorageKey);
+            localStorage.removeItem(checkinsStorageKey);
+            localStorage.removeItem(lastThreadStorageKey);
+            console.log('Guest localStorage cleared after sync');
           }
         }
 

--- a/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
+++ b/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from 'react';
+import { getThreadsForUser } from '../../lib/getThreadsForUser';
+import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
+import { importGuestThreadsForUser } from '../../lib/importGuestThreadsForUser';
+import { importGuestCheckinsForUser } from '../../lib/importGuestCheckinsForUser';
+import { getCheckinsForUser } from '../../lib/getCheckinsForUser';
+import type { Checkin, Thread } from '../types/types';
+
+type UseAuthWorkspaceBootstrapParams = {
+  user: { id: string } | null;
+  selectedThreadId: string | null;
+  setSelectedThreadId: (id: string | null) => void;
+  setThreadsState: React.Dispatch<React.SetStateAction<Thread[]>>;
+  setCheckinsHistory: React.Dispatch<React.SetStateAction<Checkin[]>>;
+  threadsStateRef: React.RefObject<Thread[]>;
+  checkinsHistoryRef: React.RefObject<Checkin[]>;
+  threadsStorageKey: string;
+  checkinsStorageKey: string;
+  lastThreadStorageKey: string;
+  syncedUserKey: string;
+};
+
+export function useAuthWorkspaceBootstrap({
+  user,
+  selectedThreadId,
+  setSelectedThreadId,
+  setThreadsState,
+  setCheckinsHistory,
+  threadsStateRef,
+  checkinsHistoryRef,
+  threadsStorageKey,
+  checkinsStorageKey,
+  lastThreadStorageKey,
+  syncedUserKey,
+}: UseAuthWorkspaceBootstrapParams) {
+  const [isBootstrappingAuthWorkspace, setIsBootstrappingAuthWorkspace] =
+    useState(false);
+
+  const hasBootstrappedAuthRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      hasBootstrappedAuthRef.current = null;
+      setIsBootstrappingAuthWorkspace(false);
+      return;
+    }
+
+    if (hasBootstrappedAuthRef.current === user.id) return;
+    hasBootstrappedAuthRef.current = user.id;
+
+    const bootstrapAuthenticatedWorkspace = async () => {
+      setIsBootstrappingAuthWorkspace(true);
+
+      try {
+        const needsGuestSync = shouldSyncGuestData(
+          user.id,
+          threadsStorageKey,
+          checkinsStorageKey,
+          syncedUserKey,
+        );
+
+        if (needsGuestSync) {
+          const guestThreads = threadsStateRef.current.filter(
+            (thread) => !thread.isArchived,
+          );
+
+          const guestCheckins = checkinsHistoryRef.current;
+
+          const threadIdsWithCheckins = new Set(
+            guestCheckins.map((checkin) => checkin.threadId),
+          );
+
+          const threadsToSync = guestThreads.filter(
+            (thread) => !thread.isSeed || threadIdsWithCheckins.has(thread.id),
+          );
+
+          if (threadsToSync.length > 0) {
+            const threadIdMap = await importGuestThreadsForUser(
+              user.id,
+              threadsToSync,
+            );
+
+            const guestLastThreadId =
+              localStorage.getItem(lastThreadStorageKey);
+
+            const syncedLastThreadId =
+              (selectedThreadId && threadIdMap[selectedThreadId]) ||
+              (guestLastThreadId && threadIdMap[guestLastThreadId]) ||
+              null;
+
+            if (syncedLastThreadId) {
+              setSelectedThreadId(syncedLastThreadId);
+              localStorage.setItem(lastThreadStorageKey, syncedLastThreadId);
+            }
+
+            await importGuestCheckinsForUser(
+              user.id,
+              guestCheckins,
+              threadIdMap,
+            );
+
+            localStorage.setItem(syncedUserKey, user.id);
+          }
+        }
+
+        const supabaseThreads = await getThreadsForUser(user.id);
+        const mappedThreads = supabaseThreads.map((thread) => ({
+          id: thread.id,
+          name: thread.name,
+          isArchived: thread.is_archived,
+        }));
+        setThreadsState(mappedThreads);
+
+        const supabaseCheckins = await getCheckinsForUser(user.id);
+        const mappedCheckins = supabaseCheckins.map((checkin) => ({
+          id: checkin.id,
+          threadId: checkin.thread_id,
+          text: checkin.text,
+          note: checkin.note ?? undefined,
+          createdAt: new Date(checkin.created_at).getTime(),
+        }));
+        setCheckinsHistory(mappedCheckins);
+      } catch (error) {
+        console.error('Failed to bootstrap authenticated workspace', error);
+        hasBootstrappedAuthRef.current = null;
+      } finally {
+        setIsBootstrappingAuthWorkspace(false);
+      }
+    };
+
+    bootstrapAuthenticatedWorkspace();
+  }, [
+    user,
+    selectedThreadId,
+    setSelectedThreadId,
+    setThreadsState,
+    setCheckinsHistory,
+    threadsStateRef,
+    checkinsHistoryRef,
+    threadsStorageKey,
+    checkinsStorageKey,
+    lastThreadStorageKey,
+    syncedUserKey,
+  ]);
+
+  return { isBootstrappingAuthWorkspace };
+}

--- a/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
+++ b/frontend/src/hooks/useAuthWorkspaceBootstrap.ts
@@ -83,10 +83,13 @@ export function useAuthWorkspaceBootstrap({
             const guestLastThreadId =
               localStorage.getItem(lastThreadStorageKey);
 
+            console.log('GUEST SYNC THREAD MAP', {
+              guestLastThreadId,
+              threadIdMap,
+            });
+
             const syncedLastThreadId =
-              (selectedThreadId && threadIdMap[selectedThreadId]) ||
-              (guestLastThreadId && threadIdMap[guestLastThreadId]) ||
-              null;
+              (guestLastThreadId && threadIdMap[guestLastThreadId]) || null;
 
             if (syncedLastThreadId) {
               setSelectedThreadId(syncedLastThreadId);
@@ -120,6 +123,52 @@ export function useAuthWorkspaceBootstrap({
           createdAt: new Date(checkin.created_at).getTime(),
         }));
         setCheckinsHistory(mappedCheckins);
+        const activeThreads = mappedThreads.filter(
+          (thread) => !thread.isArchived,
+        );
+        const availableThreadIds = new Set(
+          activeThreads.map((thread) => thread.id),
+        );
+        const firstActiveThreadId = activeThreads[0]?.id ?? null;
+
+        const persistedLastThreadId =
+          localStorage.getItem(lastThreadStorageKey);
+
+        const mostRecentCheckin = mappedCheckins.reduce<Checkin | null>(
+          (latestCheckin, currentCheckin) =>
+            !latestCheckin || currentCheckin.createdAt > latestCheckin.createdAt
+              ? currentCheckin
+              : latestCheckin,
+          null,
+        );
+
+        const candidateIds = [
+          persistedLastThreadId,
+          mostRecentCheckin?.threadId ?? null,
+          firstActiveThreadId,
+        ];
+
+        const finalSelectedThreadId =
+          candidateIds.find(
+            (threadId): threadId is string =>
+              !!threadId && availableThreadIds.has(threadId),
+          ) ?? null;
+
+        console.log('AUTH FINAL SELECTION', {
+          persistedLastThreadId,
+          mostRecentCheckinThreadId: mostRecentCheckin?.threadId ?? null,
+          firstActiveThreadId,
+          availableThreadIds: Array.from(availableThreadIds),
+          finalSelectedThreadId,
+        });
+
+        setSelectedThreadId(finalSelectedThreadId);
+
+        if (finalSelectedThreadId) {
+          localStorage.setItem(lastThreadStorageKey, finalSelectedThreadId);
+        } else {
+          localStorage.removeItem(lastThreadStorageKey);
+        }
       } catch (error) {
         console.error('Failed to bootstrap authenticated workspace', error);
         hasBootstrappedAuthRef.current = null;

--- a/frontend/src/hooks/useDefaultSelectedThread.ts
+++ b/frontend/src/hooks/useDefaultSelectedThread.ts
@@ -9,10 +9,12 @@ export function useDefaultSelectedThread(
   checkinsHistory: Checkin[],
   threadsState: Thread[],
   lastThreadStorageKey: string,
+  isSelectionBlocked: boolean,
 ) {
   // set default selected thread
   useEffect(() => {
     if (!hasLoadedCheckins || !hasLoadedThreads) return;
+    if (isSelectionBlocked) return;
 
     const activeThreads = threadsState.filter((thread) => !thread.isArchived);
     const availableThreadIds = new Set(
@@ -37,22 +39,37 @@ export function useDefaultSelectedThread(
     const candidateIds = [
       // if the user already had a last active thread, keep that continuity first
       lastThreadId,
-
       // otherwise use the thread of the most recent checkin
-      mostRecentCheckin?.threadId ?? null,
 
+      mostRecentCheckin?.threadId ?? null,
       // if this is a brand-new user, just show the first available thread
+
       firstActiveThreadId,
     ];
 
     // only select ids that still exist in the current thread list
+
     const firstValidThreadId =
       candidateIds.find(
         (threadId): threadId is string =>
           !!threadId && availableThreadIds.has(threadId),
       ) ?? null;
 
+    console.log('default selection candidates', {
+      selectedThreadId,
+      lastThreadId,
+      mostRecentCheckinThreadId: mostRecentCheckin?.threadId ?? null,
+      firstActiveThreadId,
+      availableThreadIds: Array.from(availableThreadIds),
+      firstValidThreadId,
+      isSelectionBlocked,
+    });
+
     setSelectedThreadId(firstValidThreadId);
+
+    if (firstValidThreadId) {
+      localStorage.setItem(lastThreadStorageKey, firstValidThreadId);
+    }
   }, [
     hasLoadedCheckins,
     hasLoadedThreads,
@@ -61,5 +78,6 @@ export function useDefaultSelectedThread(
     threadsState,
     lastThreadStorageKey,
     setSelectedThreadId,
+    isSelectionBlocked,
   ]);
 }

--- a/frontend/src/hooks/useDefaultSelectedThread.ts
+++ b/frontend/src/hooks/useDefaultSelectedThread.ts
@@ -14,11 +14,11 @@ export function useDefaultSelectedThread(
   useEffect(() => {
     if (!hasLoadedCheckins || !hasLoadedThreads) return;
 
+    const activeThreads = threadsState.filter((thread) => !thread.isArchived);
     const availableThreadIds = new Set(
-      threadsState
-        .filter((thread) => !thread.isArchived)
-        .map((thread) => thread.id),
+      activeThreads.map((thread) => thread.id),
     );
+    const firstActiveThreadId = activeThreads[0]?.id ?? null;
 
     // if current selected thread still exists, keep it
     if (selectedThreadId && availableThreadIds.has(selectedThreadId)) return;
@@ -42,7 +42,7 @@ export function useDefaultSelectedThread(
       lastThreadId,
 
       // if this is a brand-new user, just show the first available thread
-      threadsState.find((thread) => !thread.isArchived)?.id ?? null,
+      firstActiveThreadId,
     ];
 
     // only select ids that still exist in the current thread list

--- a/frontend/src/hooks/useDefaultSelectedThread.ts
+++ b/frontend/src/hooks/useDefaultSelectedThread.ts
@@ -35,11 +35,11 @@ export function useDefaultSelectedThread(
     );
 
     const candidateIds = [
-      // if the user has checkins, take the thread of the most recent checkin
-      mostRecentCheckin?.threadId ?? null,
-
-      // if no checkins exist yet, fall back to the last thread the user clicked
+      // if the user already had a last active thread, keep that continuity first
       lastThreadId,
+
+      // otherwise use the thread of the most recent checkin
+      mostRecentCheckin?.threadId ?? null,
 
       // if this is a brand-new user, just show the first available thread
       firstActiveThreadId,

--- a/frontend/src/hooks/useDefaultSelectedThread.ts
+++ b/frontend/src/hooks/useDefaultSelectedThread.ts
@@ -13,7 +13,15 @@ export function useDefaultSelectedThread(
   // set default selected thread
   useEffect(() => {
     if (!hasLoadedCheckins || !hasLoadedThreads) return;
-    if (selectedThreadId) return;
+
+    const availableThreadIds = new Set(
+      threadsState
+        .filter((thread) => !thread.isArchived)
+        .map((thread) => thread.id),
+    );
+
+    // if current selected thread still exists, keep it
+    if (selectedThreadId && availableThreadIds.has(selectedThreadId)) return;
 
     const lastThreadId = localStorage.getItem(lastThreadStorageKey);
 
@@ -26,16 +34,25 @@ export function useDefaultSelectedThread(
       null,
     );
 
-    const defaultThreadId =
-      // 	if the user has checkins,	take the thread of the most recent checkin
-      mostRecentCheckin?.threadId ??
-      // 	if no check-ins exist yet, fall back to the last thread the user clicked
-      lastThreadId ??
-      // 	if this is a brand-new user, just show the first thread
-      threadsState[0]?.id ??
-      null;
+    const candidateIds = [
+      // if the user has checkins, take the thread of the most recent checkin
+      mostRecentCheckin?.threadId ?? null,
 
-    setSelectedThreadId(defaultThreadId);
+      // if no checkins exist yet, fall back to the last thread the user clicked
+      lastThreadId,
+
+      // if this is a brand-new user, just show the first available thread
+      threadsState.find((thread) => !thread.isArchived)?.id ?? null,
+    ];
+
+    // only select ids that still exist in the current thread list
+    const firstValidThreadId =
+      candidateIds.find(
+        (threadId): threadId is string =>
+          !!threadId && availableThreadIds.has(threadId),
+      ) ?? null;
+
+    setSelectedThreadId(firstValidThreadId);
   }, [
     hasLoadedCheckins,
     hasLoadedThreads,

--- a/frontend/src/hooks/useThreadsStorage.ts
+++ b/frontend/src/hooks/useThreadsStorage.ts
@@ -1,15 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Thread } from '../types/types';
 
 export function useThreadsStorage(
   storageKey: string,
   fallbackThreads: Thread[],
+  isEnabled: boolean,
 ) {
   const [threadsState, setThreadsState] = useState<Thread[]>(fallbackThreads);
   const [hasLoadedThreads, setHasLoadedThreads] = useState(false);
+  const skipNextSaveRef = useRef(false);
 
-  // load threads from localStorage
+  // load threads from localStorage only in guest mode
   useEffect(() => {
+    if (!isEnabled) {
+      setHasLoadedThreads(false);
+      return;
+    }
+
+    skipNextSaveRef.current = true;
+
     const savedThreads = localStorage.getItem(storageKey);
 
     if (savedThreads) {
@@ -20,17 +29,24 @@ export function useThreadsStorage(
         console.warn('Failed to parse saved threads from localStorage', error);
         setThreadsState(fallbackThreads);
       }
+    } else {
+      setThreadsState(fallbackThreads);
     }
 
     setHasLoadedThreads(true);
-  }, [storageKey, fallbackThreads]);
+  }, [storageKey, fallbackThreads, isEnabled]);
 
-  // save edited threads to localStorage
+  // save threads to localStorage only in guest mode
   useEffect(() => {
-    if (!hasLoadedThreads) return;
+    if (!hasLoadedThreads || !isEnabled) return;
+
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
 
     localStorage.setItem(storageKey, JSON.stringify(threadsState));
-  }, [threadsState, hasLoadedThreads, storageKey]);
+  }, [threadsState, hasLoadedThreads, storageKey, isEnabled]);
 
   return {
     threadsState,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 
 import { useAuthUser } from '../hooks/useAuthUser';
 import { getThreadsForUser } from '../../lib/getThreadsForUser';
+import { createThreadForUser } from '../../lib/createThreadForUser';
 import '../styles/pages/home.css';
 import { threads } from '../data/threads';
 import { useState, useRef, useEffect } from 'react';
@@ -115,9 +116,30 @@ export const HomePage = () => {
   };
 
   // add
-  const handleAddThread = (name: string) => {
-    const trimmedName = name.trim().slice(0, 40); // enforce max length
+  const handleAddThread = async (name: string) => {
+    const trimmedName = name.trim().slice(0, 40);
     if (!trimmedName) return;
+
+    if (user) {
+      try {
+        const createdThread = await createThreadForUser(user.id, trimmedName);
+
+        const mappedThread = {
+          id: createdThread.id,
+          name: createdThread.name,
+          isArchived: createdThread.is_archived,
+        };
+
+        setThreadsState((prev) => [...prev, mappedThread]);
+        setSelectedThreadId(mappedThread.id);
+        setEditingThreadId(null);
+        setThreadIdPendingArchive(null);
+        return;
+      } catch (error) {
+        console.error('Failed to create thread in Supabase', error);
+        return;
+      }
+    }
 
     const newThread = {
       id: crypto.randomUUID(),
@@ -125,7 +147,6 @@ export const HomePage = () => {
     };
 
     setThreadsState((prev) => [...prev, newThread]);
-    // Nice UX: automatically open the new thread
     setSelectedThreadId(newThread.id);
     setEditingThreadId(null);
     setThreadIdPendingArchive(null);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -78,6 +78,7 @@ export const HomePage = () => {
     checkinsHistory,
     threadsState,
     LAST_THREAD_STORAGE_KEY,
+    !!user && isBootstrappingAuthWorkspace,
   );
 
   // HELPERS
@@ -85,10 +86,21 @@ export const HomePage = () => {
   const getCheckinsCount = (threadId: string) =>
     checkinsHistoryRef.current.filter((c) => c.threadId === threadId).length;
 
+  const selectThread = (threadId: string | null) => {
+    setSelectedThreadId(threadId);
+
+    if (threadId) {
+      localStorage.setItem(LAST_THREAD_STORAGE_KEY, threadId);
+    } else {
+      localStorage.removeItem(LAST_THREAD_STORAGE_KEY);
+    }
+  };
+
   // HANDLERS
   // thread selection
   const handleThreadClick = (threadId: string) => {
-    setSelectedThreadId(threadId);
+    selectThread(threadId);
+    localStorage.setItem(LAST_THREAD_STORAGE_KEY, threadId);
     setThreadIdPendingArchive(null); // close any pending archive confirm UI
     setEditingThreadId(null); // NEW: prevents rename UI sticking
   };
@@ -125,7 +137,7 @@ export const HomePage = () => {
         };
 
         setThreadsState((prev) => [...prev, mappedThread]);
-        setSelectedThreadId(mappedThread.id);
+        selectThread(mappedThread.id);
         setEditingThreadId(null);
         setThreadIdPendingArchive(null);
         return;
@@ -141,7 +153,7 @@ export const HomePage = () => {
     };
 
     setThreadsState((prev) => [...prev, newThread]);
-    setSelectedThreadId(newThread.id);
+    selectThread(newThread.id);
     setEditingThreadId(null);
     setThreadIdPendingArchive(null);
   };
@@ -157,7 +169,7 @@ export const HomePage = () => {
       if (selectedThreadId === threadId) {
         const nextThread = updated.find((t) => !t.isArchived);
 
-        setSelectedThreadId(nextThread?.id ?? null);
+        selectThread(nextThread?.id ?? null);
       }
 
       return updated;
@@ -207,10 +219,18 @@ export const HomePage = () => {
   };
 
   // UI DATA
+  console.log(
+    'LAST_THREAD_STORAGE_KEY:',
+    localStorage.getItem(LAST_THREAD_STORAGE_KEY),
+  );
   console.log('selectedThreadId:', selectedThreadId);
   console.log(
     'threadsState ids:',
     threadsState.map((thread) => thread.id),
+  );
+  console.log(
+    'checkin thread ids:',
+    checkinsHistory.map((checkin) => checkin.threadId),
   );
 
   const selectedThreadData =

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -24,7 +24,7 @@ const LAST_THREAD_STORAGE_KEY = 'goback_last_thread_v1';
 const HERO_DISMISSED_KEY = 'goback_hero_dismissed_v1';
 
 export const HomePage = () => {
-  const { user } = useAuthUser();
+  const { user, isCheckingAuth } = useAuthUser();
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
   // split state: title + optional note
@@ -37,6 +37,7 @@ export const HomePage = () => {
   const { threadsState, setThreadsState, hasLoadedThreads } = useThreadsStorage(
     THREADS_STORAGE_KEY,
     threads,
+    !user, // only enable localStorage for guest users
   );
 
   useEffect(() => {
@@ -49,14 +50,13 @@ export const HomePage = () => {
         console.log('Logged in user id:', user.id);
         console.log('Threads from Supabase:', supabaseThreads);
 
-        if (supabaseThreads) {
-          const mappedThreads = supabaseThreads.map((thread) => ({
-            id: thread.id,
-            name: thread.name,
-            isArchived: thread.is_archived,
-          }));
-          setThreadsState(mappedThreads);
-        }
+        const mappedThreads = supabaseThreads.map((thread) => ({
+          id: thread.id,
+          name: thread.name,
+          isArchived: thread.is_archived,
+        }));
+
+        setThreadsState(mappedThreads);
       } catch (error) {
         console.error('Failed to load threads from Supabase', error);
       }
@@ -274,6 +274,17 @@ export const HomePage = () => {
     });
   };
   // Feature "Hero" end
+
+  if (isCheckingAuth) {
+    return (
+      <>
+        <Header heroDismissed={false} />
+        <main className="page">
+          <p>Loading...</p>
+        </main>
+      </>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,7 @@
 //	If a function mutates global/shared state → it belongs in HomePage
 
+import { useAuthUser } from '../hooks/useAuthUser';
+import { getThreadsForUser } from '../../lib/getThreadsForUser';
 import '../styles/pages/home.css';
 import { threads } from '../data/threads';
 import { useState, useRef, useEffect } from 'react';
@@ -21,6 +23,7 @@ const LAST_THREAD_STORAGE_KEY = 'goback_last_thread_v1';
 const HERO_DISMISSED_KEY = 'goback_hero_dismissed_v1';
 
 export const HomePage = () => {
+  const { user } = useAuthUser();
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
   // split state: title + optional note
@@ -34,6 +37,32 @@ export const HomePage = () => {
     THREADS_STORAGE_KEY,
     threads,
   );
+
+  useEffect(() => {
+    if (!user) return;
+
+    const loadThreads = async () => {
+      try {
+        const supabaseThreads = await getThreadsForUser(user.id);
+
+        console.log('Logged in user id:', user.id);
+        console.log('Threads from Supabase:', supabaseThreads);
+
+        if (supabaseThreads) {
+          const mappedThreads = supabaseThreads.map((thread) => ({
+            id: thread.id,
+            name: thread.name,
+            isArchived: thread.is_archived,
+          }));
+          setThreadsState(mappedThreads);
+        }
+      } catch (error) {
+        console.error('Failed to load threads from Supabase', error);
+      }
+    };
+
+    loadThreads();
+  }, [user, setThreadsState]);
 
   const { checkinsHistory, setCheckinsHistory, hasLoadedCheckins } =
     useCheckinsStorage(CHECKINS_STORAGE_KEY);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -249,10 +249,17 @@ export const HomePage = () => {
     : 0;
 
   useEffect(() => {
+    if (user) return; // authenticated users use real data, so seed checkins are guest-only
     if (!hasLoadedCheckins || !hasLoadedThreads) return;
 
-    // already have steps → don't seed
-    if (checkinsHistory.length > 0) return;
+    const currentThreadIds = new Set(threadsState.map((thread) => thread.id));
+
+    const hasCheckinsForCurrentThreads = checkinsHistory.some((checkin) =>
+      currentThreadIds.has(checkin.threadId),
+    );
+
+    // if current guest threads already have checkins, don't seed again
+    if (hasCheckinsForCurrentThreads) return;
 
     const seedCheckins = createSeedCheckins(threadsState);
     if (seedCheckins.length === 0) return;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,6 @@
 //	If a function mutates global/shared state → it belongs in HomePage
 
 import { useAuthUser } from '../hooks/useAuthUser';
-import { getThreadsForUser } from '../../lib/getThreadsForUser';
-import { createThreadForUser } from '../../lib/createThreadForUser';
 import '../styles/pages/home.css';
 import { threads } from '../data/threads';
 import { useState, useRef, useEffect } from 'react';
@@ -12,8 +10,11 @@ import type { Checkin } from '../types/types';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Hero } from '../components/Hero';
+import { getThreadsForUser } from '../../lib/getThreadsForUser';
+import { createThreadForUser } from '../../lib/createThreadForUser';
 import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
 import { importGuestThreadsForUser } from '../../lib/importGuestThreadsForUser';
+import { importGuestCheckinsForUser } from '../../lib/importGuestCheckinsForUser';
 
 import { useCheckinsStorage } from '../hooks/useCheckinsStorage';
 import { useThreadsStorage } from '../hooks/useThreadsStorage';
@@ -93,6 +94,18 @@ export const HomePage = () => {
             console.log('Imported guest threads');
             console.log('Thread id map:', threadIdMap);
 
+            const guestCheckins = JSON.parse(
+              localStorage.getItem(CHECKINS_STORAGE_KEY) ?? '[]',
+            );
+
+            await importGuestCheckinsForUser(
+              user.id,
+              guestCheckins,
+              threadIdMap,
+            );
+            
+            console.log('Imported guest checkins');
+
             localStorage.setItem(SYNCED_USER_KEY, user.id);
           }
         }
@@ -109,7 +122,6 @@ export const HomePage = () => {
 
         // reset selection because guest ids no longer exist after sync
         setSelectedThreadId(mappedThreads[0]?.id ?? null);
-        
       } catch (error) {
         console.error('Failed to bootstrap authenticated workspace', error);
         hasBootstrappedAuthRef.current = null;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -13,6 +13,7 @@ import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Hero } from '../components/Hero';
 import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
+import { importGuestThreadsForUser } from '../../lib/importGuestThreadsForUser';
 
 import { useCheckinsStorage } from '../hooks/useCheckinsStorage';
 import { useThreadsStorage } from '../hooks/useThreadsStorage';
@@ -27,6 +28,7 @@ const SYNCED_USER_KEY = 'goback_synced_user_id';
 
 export const HomePage = () => {
   const { user, isCheckingAuth } = useAuthUser();
+
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
   // split state: title + optional note
@@ -42,24 +44,60 @@ export const HomePage = () => {
     !user, // only enable localStorage for guest users
   );
 
+  const threadsStateRef = useRef(threadsState);
+  const hasBootstrappedAuthRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!user) return;
+    threadsStateRef.current = threadsState;
+  }, [threadsState]);
 
-    const needsGuestSync = shouldSyncGuestData(
-      user.id,
-      THREADS_STORAGE_KEY,
-      CHECKINS_STORAGE_KEY,
-      SYNCED_USER_KEY,
-    );
+  useEffect(() => {
+    if (!user) {
+      hasBootstrappedAuthRef.current = null;
+      return;
+    }
 
-    console.log('Needs guest sync:', needsGuestSync);
+    if (hasBootstrappedAuthRef.current === user.id) return;
+    hasBootstrappedAuthRef.current = user.id;
 
-    const loadThreads = async () => {
+    const bootstrapAuthenticatedWorkspace = async () => {
       try {
-        const supabaseThreads = await getThreadsForUser(user.id);
+        const needsGuestSync = shouldSyncGuestData(
+          user.id,
+          THREADS_STORAGE_KEY,
+          CHECKINS_STORAGE_KEY,
+          SYNCED_USER_KEY,
+        );
 
-        console.log('Logged in user id:', user.id);
-        console.log('Threads from Supabase:', supabaseThreads);
+        console.log('Needs guest sync:', needsGuestSync);
+
+        if (needsGuestSync) {
+          const guestThreads = threadsStateRef.current.filter(
+            (thread) => !thread.isArchived,
+          );
+
+          const hasUserCreatedThreads = guestThreads.some(
+            (thread) => !thread.isSeed,
+          );
+
+          const threadsToSync = hasUserCreatedThreads
+            ? guestThreads.filter((thread) => !thread.isSeed)
+            : guestThreads;
+
+          if (threadsToSync.length > 0) {
+            const threadIdMap = await importGuestThreadsForUser(
+              user.id,
+              threadsToSync,
+            );
+
+            console.log('Imported guest threads');
+            console.log('Thread id map:', threadIdMap);
+
+            localStorage.setItem(SYNCED_USER_KEY, user.id);
+          }
+        }
+
+        const supabaseThreads = await getThreadsForUser(user.id);
 
         const mappedThreads = supabaseThreads.map((thread) => ({
           id: thread.id,
@@ -68,12 +106,17 @@ export const HomePage = () => {
         }));
 
         setThreadsState(mappedThreads);
+
+        // reset selection because guest ids no longer exist after sync
+        setSelectedThreadId(mappedThreads[0]?.id ?? null);
+        
       } catch (error) {
-        console.error('Failed to load threads from Supabase', error);
+        console.error('Failed to bootstrap authenticated workspace', error);
+        hasBootstrappedAuthRef.current = null;
       }
     };
 
-    loadThreads();
+    bootstrapAuthenticatedWorkspace();
   }, [user, setThreadsState]);
 
   const { checkinsHistory, setCheckinsHistory, hasLoadedCheckins } =
@@ -224,8 +267,16 @@ export const HomePage = () => {
   };
 
   // UI DATA
+  console.log('selectedThreadId:', selectedThreadId);
+  console.log(
+    'threadsState ids:',
+    threadsState.map((thread) => thread.id),
+  );
+
   const selectedThreadData =
     threadsState.find((thread) => thread.id === selectedThreadId) ?? null;
+
+  console.log('selectedThreadData:', selectedThreadData);
 
   const selectedThreadCheckins = checkinsHistory
     .filter((checkin) => checkin.threadId === selectedThreadId)

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ import { createThreadForUser } from '../../lib/createThreadForUser';
 import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
 import { importGuestThreadsForUser } from '../../lib/importGuestThreadsForUser';
 import { importGuestCheckinsForUser } from '../../lib/importGuestCheckinsForUser';
+import { getCheckinsForUser } from '../../lib/getCheckinsForUser';
 
 import { useCheckinsStorage } from '../hooks/useCheckinsStorage';
 import { useThreadsStorage } from '../hooks/useThreadsStorage';
@@ -38,6 +39,8 @@ export const HomePage = () => {
   const [threadIdPendingArchive, setThreadIdPendingArchive] = useState<
     string | null
   >(null);
+  const [isBootstrappingAuthWorkspace, setIsBootstrappingAuthWorkspace] =
+    useState(false);
 
   const { threadsState, setThreadsState, hasLoadedThreads } = useThreadsStorage(
     THREADS_STORAGE_KEY,
@@ -45,7 +48,11 @@ export const HomePage = () => {
     !user, // only enable localStorage for guest users
   );
 
+  const { checkinsHistory, setCheckinsHistory, hasLoadedCheckins } =
+    useCheckinsStorage(CHECKINS_STORAGE_KEY);
+
   const threadsStateRef = useRef(threadsState);
+  const checkinsHistoryRef = useRef<Checkin[]>([]);
   const hasBootstrappedAuthRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -53,8 +60,13 @@ export const HomePage = () => {
   }, [threadsState]);
 
   useEffect(() => {
+    checkinsHistoryRef.current = checkinsHistory;
+  }, [checkinsHistory]);
+
+  useEffect(() => {
     if (!user) {
       hasBootstrappedAuthRef.current = null;
+      setIsBootstrappingAuthWorkspace(false);
       return;
     }
 
@@ -62,6 +74,8 @@ export const HomePage = () => {
     hasBootstrappedAuthRef.current = user.id;
 
     const bootstrapAuthenticatedWorkspace = async () => {
+      setIsBootstrappingAuthWorkspace(true);
+
       try {
         const needsGuestSync = shouldSyncGuestData(
           user.id,
@@ -70,20 +84,20 @@ export const HomePage = () => {
           SYNCED_USER_KEY,
         );
 
-        console.log('Needs guest sync:', needsGuestSync);
-
         if (needsGuestSync) {
           const guestThreads = threadsStateRef.current.filter(
             (thread) => !thread.isArchived,
           );
 
-          const hasUserCreatedThreads = guestThreads.some(
-            (thread) => !thread.isSeed,
+          const guestCheckins = checkinsHistoryRef.current;
+
+          const threadIdsWithCheckins = new Set(
+            guestCheckins.map((checkin) => checkin.threadId),
           );
 
-          const threadsToSync = hasUserCreatedThreads
-            ? guestThreads.filter((thread) => !thread.isSeed)
-            : guestThreads;
+          const threadsToSync = guestThreads.filter(
+            (thread) => !thread.isSeed || threadIdsWithCheckins.has(thread.id),
+          );
 
           if (threadsToSync.length > 0) {
             const threadIdMap = await importGuestThreadsForUser(
@@ -91,57 +105,57 @@ export const HomePage = () => {
               threadsToSync,
             );
 
-            console.log('Imported guest threads');
-            console.log('Thread id map:', threadIdMap);
-
-            const guestCheckins = JSON.parse(
-              localStorage.getItem(CHECKINS_STORAGE_KEY) ?? '[]',
+            const guestLastThreadId = localStorage.getItem(
+              LAST_THREAD_STORAGE_KEY,
             );
+
+            const syncedLastThreadId =
+              (selectedThreadId && threadIdMap[selectedThreadId]) ||
+              (guestLastThreadId && threadIdMap[guestLastThreadId]) ||
+              null;
+
+            if (syncedLastThreadId) {
+              setSelectedThreadId(syncedLastThreadId);
+              localStorage.setItem(LAST_THREAD_STORAGE_KEY, syncedLastThreadId);
+            }
 
             await importGuestCheckinsForUser(
               user.id,
               guestCheckins,
               threadIdMap,
             );
-            
-            console.log('Imported guest checkins');
 
             localStorage.setItem(SYNCED_USER_KEY, user.id);
           }
         }
 
         const supabaseThreads = await getThreadsForUser(user.id);
-
         const mappedThreads = supabaseThreads.map((thread) => ({
           id: thread.id,
           name: thread.name,
           isArchived: thread.is_archived,
         }));
-
         setThreadsState(mappedThreads);
 
-        // reset selection because guest ids no longer exist after sync
-        setSelectedThreadId(mappedThreads[0]?.id ?? null);
+        const supabaseCheckins = await getCheckinsForUser(user.id);
+        const mappedCheckins = supabaseCheckins.map((checkin) => ({
+          id: checkin.id,
+          threadId: checkin.thread_id,
+          text: checkin.text,
+          note: checkin.note ?? undefined,
+          createdAt: new Date(checkin.created_at).getTime(),
+        }));
+        setCheckinsHistory(mappedCheckins);
       } catch (error) {
         console.error('Failed to bootstrap authenticated workspace', error);
         hasBootstrappedAuthRef.current = null;
+      } finally {
+        setIsBootstrappingAuthWorkspace(false);
       }
     };
 
     bootstrapAuthenticatedWorkspace();
-  }, [user, setThreadsState]);
-
-  const { checkinsHistory, setCheckinsHistory, hasLoadedCheckins } =
-    useCheckinsStorage(CHECKINS_STORAGE_KEY);
-
-  //  always-latest snapshot of checkins (doesn't wait for re-render)
-  const checkinsHistoryRef = useRef<Checkin[]>([]);
-
-  // keep ref synced on normal renders
-  useEffect(() => {
-    checkinsHistoryRef.current = checkinsHistory;
-  }, [checkinsHistory]);
-
+  }, [user, selectedThreadId, setThreadsState, setCheckinsHistory]);
   useDefaultSelectedThread(
     hasLoadedCheckins,
     hasLoadedThreads,
@@ -378,6 +392,7 @@ export const HomePage = () => {
 
         <article className="panel goback-panel" ref={gobackSectionRef}>
           <GoBackCard
+            isLoadingSelection={isBootstrappingAuthWorkspace}
             checkinsForSelectedThread={selectedThreadCheckins}
             selectedThread={selectedThreadData}
             checkinTitle={checkinTitle}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -10,17 +10,13 @@ import type { Checkin } from '../types/types';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Hero } from '../components/Hero';
-import { getThreadsForUser } from '../../lib/getThreadsForUser';
 import { createThreadForUser } from '../../lib/createThreadForUser';
-import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
-import { importGuestThreadsForUser } from '../../lib/importGuestThreadsForUser';
-import { importGuestCheckinsForUser } from '../../lib/importGuestCheckinsForUser';
-import { getCheckinsForUser } from '../../lib/getCheckinsForUser';
 
 import { useCheckinsStorage } from '../hooks/useCheckinsStorage';
 import { useThreadsStorage } from '../hooks/useThreadsStorage';
 import { useDefaultSelectedThread } from '../hooks/useDefaultSelectedThread';
 import { createSeedCheckins } from '../data/seed';
+import { useAuthWorkspaceBootstrap } from '../hooks/useAuthWorkspaceBootstrap';
 
 const CHECKINS_STORAGE_KEY = 'goback_checkins_v1';
 const THREADS_STORAGE_KEY = 'goback_threads_v1';
@@ -39,8 +35,6 @@ export const HomePage = () => {
   const [threadIdPendingArchive, setThreadIdPendingArchive] = useState<
     string | null
   >(null);
-  const [isBootstrappingAuthWorkspace, setIsBootstrappingAuthWorkspace] =
-    useState(false);
 
   const { threadsState, setThreadsState, hasLoadedThreads } = useThreadsStorage(
     THREADS_STORAGE_KEY,
@@ -53,7 +47,6 @@ export const HomePage = () => {
 
   const threadsStateRef = useRef(threadsState);
   const checkinsHistoryRef = useRef<Checkin[]>([]);
-  const hasBootstrappedAuthRef = useRef<string | null>(null);
 
   useEffect(() => {
     threadsStateRef.current = threadsState;
@@ -63,99 +56,20 @@ export const HomePage = () => {
     checkinsHistoryRef.current = checkinsHistory;
   }, [checkinsHistory]);
 
-  useEffect(() => {
-    if (!user) {
-      hasBootstrappedAuthRef.current = null;
-      setIsBootstrappingAuthWorkspace(false);
-      return;
-    }
+  const { isBootstrappingAuthWorkspace } = useAuthWorkspaceBootstrap({
+    user,
+    selectedThreadId,
+    setSelectedThreadId,
+    setThreadsState,
+    setCheckinsHistory,
+    threadsStateRef,
+    checkinsHistoryRef,
+    threadsStorageKey: THREADS_STORAGE_KEY,
+    checkinsStorageKey: CHECKINS_STORAGE_KEY,
+    lastThreadStorageKey: LAST_THREAD_STORAGE_KEY,
+    syncedUserKey: SYNCED_USER_KEY,
+  });
 
-    if (hasBootstrappedAuthRef.current === user.id) return;
-    hasBootstrappedAuthRef.current = user.id;
-
-    const bootstrapAuthenticatedWorkspace = async () => {
-      setIsBootstrappingAuthWorkspace(true);
-
-      try {
-        const needsGuestSync = shouldSyncGuestData(
-          user.id,
-          THREADS_STORAGE_KEY,
-          CHECKINS_STORAGE_KEY,
-          SYNCED_USER_KEY,
-        );
-
-        if (needsGuestSync) {
-          const guestThreads = threadsStateRef.current.filter(
-            (thread) => !thread.isArchived,
-          );
-
-          const guestCheckins = checkinsHistoryRef.current;
-
-          const threadIdsWithCheckins = new Set(
-            guestCheckins.map((checkin) => checkin.threadId),
-          );
-
-          const threadsToSync = guestThreads.filter(
-            (thread) => !thread.isSeed || threadIdsWithCheckins.has(thread.id),
-          );
-
-          if (threadsToSync.length > 0) {
-            const threadIdMap = await importGuestThreadsForUser(
-              user.id,
-              threadsToSync,
-            );
-
-            const guestLastThreadId = localStorage.getItem(
-              LAST_THREAD_STORAGE_KEY,
-            );
-
-            const syncedLastThreadId =
-              (selectedThreadId && threadIdMap[selectedThreadId]) ||
-              (guestLastThreadId && threadIdMap[guestLastThreadId]) ||
-              null;
-
-            if (syncedLastThreadId) {
-              setSelectedThreadId(syncedLastThreadId);
-              localStorage.setItem(LAST_THREAD_STORAGE_KEY, syncedLastThreadId);
-            }
-
-            await importGuestCheckinsForUser(
-              user.id,
-              guestCheckins,
-              threadIdMap,
-            );
-
-            localStorage.setItem(SYNCED_USER_KEY, user.id);
-          }
-        }
-
-        const supabaseThreads = await getThreadsForUser(user.id);
-        const mappedThreads = supabaseThreads.map((thread) => ({
-          id: thread.id,
-          name: thread.name,
-          isArchived: thread.is_archived,
-        }));
-        setThreadsState(mappedThreads);
-
-        const supabaseCheckins = await getCheckinsForUser(user.id);
-        const mappedCheckins = supabaseCheckins.map((checkin) => ({
-          id: checkin.id,
-          threadId: checkin.thread_id,
-          text: checkin.text,
-          note: checkin.note ?? undefined,
-          createdAt: new Date(checkin.created_at).getTime(),
-        }));
-        setCheckinsHistory(mappedCheckins);
-      } catch (error) {
-        console.error('Failed to bootstrap authenticated workspace', error);
-        hasBootstrappedAuthRef.current = null;
-      } finally {
-        setIsBootstrappingAuthWorkspace(false);
-      }
-    };
-
-    bootstrapAuthenticatedWorkspace();
-  }, [user, selectedThreadId, setThreadsState, setCheckinsHistory]);
   useDefaultSelectedThread(
     hasLoadedCheckins,
     hasLoadedThreads,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import type { Checkin } from '../types/types';
 import { Footer } from '../components/Footer';
 import { Header } from '../components/Header';
 import { Hero } from '../components/Hero';
+import { shouldSyncGuestData } from '../../lib/shouldSyncGuestData';
 
 import { useCheckinsStorage } from '../hooks/useCheckinsStorage';
 import { useThreadsStorage } from '../hooks/useThreadsStorage';
@@ -22,6 +23,7 @@ const CHECKINS_STORAGE_KEY = 'goback_checkins_v1';
 const THREADS_STORAGE_KEY = 'goback_threads_v1';
 const LAST_THREAD_STORAGE_KEY = 'goback_last_thread_v1';
 const HERO_DISMISSED_KEY = 'goback_hero_dismissed_v1';
+const SYNCED_USER_KEY = 'goback_synced_user_id';
 
 export const HomePage = () => {
   const { user, isCheckingAuth } = useAuthUser();
@@ -42,6 +44,15 @@ export const HomePage = () => {
 
   useEffect(() => {
     if (!user) return;
+
+    const needsGuestSync = shouldSyncGuestData(
+      user.id,
+      THREADS_STORAGE_KEY,
+      CHECKINS_STORAGE_KEY,
+      SYNCED_USER_KEY,
+    );
+
+    console.log('Needs guest sync:', needsGuestSync);
 
     const loadThreads = async () => {
       try {

--- a/frontend/src/styles/components/auth-button.css
+++ b/frontend/src/styles/components/auth-button.css
@@ -1,0 +1,31 @@
+.auth-button {
+  background-color: #00796b;
+  color: white;
+  border: none;
+  font-size: 0.9rem;
+  padding: 0.55rem 1rem;
+  min-height: auto;
+  white-space: nowrap;
+}
+
+.auth-button:hover {
+  background-color: #00695c;
+}
+
+.auth-button:focus,
+.auth-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 121, 107, 0.35);
+}
+
+@media (max-width: 768px) {
+  header {
+    padding: 0.75rem 1rem;
+    gap: 0.75rem;
+  }
+
+  .auth-button {
+    font-size: 0.82rem;
+    padding: 0.5rem 0.8rem;
+  }
+}

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### What this PR delivers
- sets up authenticated thread loading from Supabase for logged-in users  
- saves newly created threads to Supabase during authenticated sessions  
- separates guest localStorage thread loading from authenticated thread loading  
- adds first guest-to-account sync logic for threads on login  
- preserves selected thread after authentication  
- restores sample checkins for guest workspace  
- prevents guest data from reappearing after logout  
- extracts auth bootstrap logic from HomePage for clearer structure  

### Why it matters
This PR establishes the first real cross-device persistence path for GoBack.

Authenticated users can now begin using Supabase as a source of truth for activities, while guest users still keep a local workspace.

It also prepares the app for the next step: moving checkins fully into authenticated persistence and stabilising tests without mixing too many moving parts in one branch.